### PR TITLE
Add default: argument to input DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ ActiveModel record.
 - **Context Restrictions** - The `input` and `output` DSL declare what context
   variables are readable and writeable, respectively. Each variable definition can optionally
   mandate a type to further protect against unexpected side effects in the context.
-  Types can be code Ruby classes, union types, or *dry-types*.
+  Types can be code Ruby classes, union types, or *dry-types*. An `input` can also
+  declare a `default:` value used when none is supplied.
 
 - **ActiveModel Validations** - All ActiveModel validation features, callbacks,
   and errors are built-in to the interactor life cycle. If a context is invalid, the service
@@ -227,6 +228,53 @@ Supported dry-types features:
 - Hash schemas: `Types::Hash.schema(name: Types::String)`
 - Optional types: `Types::String.optional`
 - Coercible types: `Types::Coercible::Integer`
+
+## Default Values
+
+An `input` may declare a `default:`, used when no value is supplied for that
+key:
+
+```ruby
+class CreateUser < Servo::Base
+  input :email
+  input :role, default: 'member'
+
+  def call
+    User.create!(email: email, role: role)
+  end
+end
+
+CreateUser.call(email: 'a@example.com')                 # role => "member"
+CreateUser.call(email: 'a@example.com', role: 'admin')  # role => "admin"
+```
+
+A default may be a literal value or a callable. Use a callable (a lambda or
+proc) when the default is mutable or computed, so each invocation receives its
+own value rather than sharing one object across calls:
+
+```ruby
+class BuildReport < Servo::Base
+  input :ids,         default: -> { [] }
+  input :generated_at, default: -> { Time.current }
+end
+```
+
+Defaults are applied before validations run, so a defaulted value is still
+subject to any `type:` or other constraints. An explicitly supplied `nil` is
+preserved rather than replaced by the default, and `default: nil` is a valid
+way to default a value to `nil`:
+
+```ruby
+class Notify < Servo::Base
+  input :channel, type: String, default: 'email'
+  input :cc,                    default: nil
+
+  validates :channel, presence: true
+end
+
+Notify.call             # channel => "email", cc => nil
+Notify.call(cc: nil)    # cc => nil (the supplied value, not the default)
+```
 
 ## Validations
 

--- a/lib/servo/callable.rb
+++ b/lib/servo/callable.rb
@@ -64,8 +64,11 @@ module Servo
 
       define_callbacks :call
 
+      before_validation :apply_input_defaults!
+
       class_attribute :_allowed_inputs, default: Set.new
       class_attribute :_allowed_outputs, default: Set.new
+      class_attribute :_input_defaults, default: {}
       class_attribute :_restrict_context, default: true
       class_attribute :_type_constraints, default: {}
     end
@@ -80,6 +83,18 @@ module Servo
 
     def respond_to_missing?(method_name, _include_private = false)
       super || context.respond_to?(method_name)
+    end
+
+    private
+
+    def apply_input_defaults!
+      self.class._input_defaults.each do |name, default|
+        next if context.to_h.key?(name)
+
+        value = default.respond_to?(:call) ? default.call : default
+
+        context.public_send("#{name}=", value)
+      end
     end
   end
 end

--- a/lib/servo/callable/dsl.rb
+++ b/lib/servo/callable/dsl.rb
@@ -11,6 +11,12 @@ module Servo
     # 2. Arrays of classes (union types): `type: [String, Date]`
     # 3. dry-types objects: `type: Types::Array.of(Types::String)`
     #
+    # Inputs may also declare a `default:`, used when no value is supplied for
+    # that key. A default may be a literal value or a callable (invoked once
+    # per call), which is the safe way to default to a mutable or computed
+    # value. Defaults are applied before validations run, so a defaulted value
+    # is still subject to any `type:` or other constraints.
+    #
     # Example:
     #
     #   class MyInteractor
@@ -26,18 +32,29 @@ module Servo
     #     input :tags, type: Types::Array.of(Types::String)
     #     input :config, type: Types::Hash.schema(host: Types::String, port: Types::Integer)
     #
+    #     # Defaults (literal and callable)
+    #     input :role,    default: 'guest'
+    #     input :manager, default: nil
+    #     input :ids,     default: -> { [] }
+    #
     #     output :greeting
     #   end
     #
     module Dsl
       BASE_CONTEXT_KEYS = %i(data error_messages errors result).freeze
 
+      # A unique, private marker meaning "no default was supplied". A real
+      # default of `nil` is recorded; an omitted default is not.
+      NO_DEFAULT = Object.new.freeze
+      private_constant :NO_DEFAULT
+
       def allowed_context_keys
         _allowed_inputs + _allowed_outputs + BASE_CONTEXT_KEYS
       end
 
-      def input(name, type: nil)
+      def input(name, default: NO_DEFAULT, type: nil)
         self._allowed_inputs = _allowed_inputs.dup.add(name)
+        self._input_defaults = _input_defaults.merge(name => default) unless default.equal?(NO_DEFAULT)
         add_type_constraint(name, type) if type
         define_context_accessor(name)
       end

--- a/spec/unit/callable_dsl_spec.rb
+++ b/spec/unit/callable_dsl_spec.rb
@@ -34,6 +34,94 @@ RSpec.describe Servo::Callable do
     end
   end
 
+  describe 'input defaults' do
+    let(:klass) do
+      Class.new do
+        Object.const_set(FactoryBot.generate(:class_name), self)
+        include Servo::Callable
+
+        input :ids,     default: -> { [] }
+        input :manager, default: 'boss'
+        input :role,    default: 'guest'
+
+        def call
+          self.result = { ids: ids, manager: manager, role: role }
+        end
+      end
+    end
+
+    it 'applies the default when no value is supplied', :aggregate_failures do
+      result = klass.call
+      expect(result).to be_success
+      expect(result.role).to eq('guest')
+      expect(result.manager).to eq('boss')
+    end
+
+    it 'uses the supplied value over the default' do
+      result = klass.call(role: 'admin')
+      expect(result).to be_success
+      expect(result.role).to eq('admin')
+    end
+
+    it 'preserves an explicitly supplied nil rather than defaulting' do
+      result = klass.call(manager: nil)
+      expect(result).to be_success
+      expect(result.manager).to be_nil
+    end
+
+    it 'invokes callable defaults fresh for each call' do
+      first = klass.call
+      first.ids << 'mutated'
+
+      second = klass.call
+
+      expect(first.ids).to eq(%w(mutated))
+      expect(second.ids).to eq([])
+    end
+
+    context 'when the default is nil' do
+      let(:nil_default_klass) do
+        Class.new do
+          Object.const_set(FactoryBot.generate(:class_name), self)
+          include Servo::Callable
+
+          input :name, default: nil
+
+          def call
+            self.result = name
+          end
+        end
+      end
+
+      it 'records nil as the default value' do
+        result = nil_default_klass.call
+        expect(result).to be_success
+        expect(result.data).to be_nil
+      end
+    end
+
+    context 'when a defaulted value violates a type constraint' do
+      let(:typed_klass) do
+        Class.new do
+          Object.const_set(FactoryBot.generate(:class_name), self)
+          include Servo::Callable
+
+          input :count, default: 'not an integer', type: Integer
+
+          def call
+            count
+          end
+        end
+      end
+
+      it 'still enforces the type constraint on the default' do
+        result = typed_klass.call
+        expect(result).to be_failure
+        expect(result.errors[:count]).to include('must be a Integer')
+      end
+    end
+  end
+
   describe 'output DSL' do
     let(:klass) do
       Class.new do


### PR DESCRIPTION
## Summary

Adds an optional `default:` argument to the `input` DSL, applied before validation when no value is supplied for that key. A default may be a literal value or a callable (invoked once per call) so mutable or computed defaults aren't shared across invocations. An explicitly supplied `nil` is preserved rather than overwritten, and `default: nil` is supported via a private sentinel that distinguishes an omitted default from a `nil` one. Because defaults run before validations, a defaulted value is still subject to any `type:` or other constraints.

## Implementation

Defaults are stored in a new `_input_defaults` class attribute and applied through a `before_validation` callback, keeping the change entirely within the DSL/Callable layer. Includes new specs covering each behavior and an updated README section.